### PR TITLE
Add debug trait to Output struct

### DIFF
--- a/hakoniwa/src/child.rs
+++ b/hakoniwa/src/child.rs
@@ -3,6 +3,7 @@ use nix::sys::wait;
 use nix::unistd::Pid;
 use os_pipe::{PipeReader, PipeWriter};
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::io::prelude::*;
 use std::time::Duration;
 use tempfile::TempDir;
@@ -62,6 +63,16 @@ pub struct Output {
 
     /// The data that the internal process wrote to stderr.
     pub stderr: Vec<u8>,
+}
+
+impl fmt::Debug for Output {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Output")
+            .field("ExitStatus", &self.status)
+            .field("stdout", &String::from_utf8_lossy(&self.stdout))
+            .field("stderr", &String::from_utf8_lossy(&self.stderr))
+            .finish()
+    }
 }
 
 /// Representation of a running or exited child process.


### PR DESCRIPTION
Generally its nice to add debug to most public api struts so that down streams like me can more easily work out what's going on.

I note that some other struts have Debug so I'm not sure if this was missed by mistake or by design?

Assuming that you do want something like this I note:

I assume most people will find from_utf8_lossy the most helpful way to view the output.

If you really want i could probably try to to it loss less and then fall back to lossy with some indication that the loss less did not work.. im not sure its worth it tho, let me know and i can tweak.