### PR TITLE
Replace deprecated SPDX license identifier

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -37,7 +37,7 @@ allow = [
 ]
 confidence-threshold = 0.8
 exceptions = [
-    { allow = ["LGPL-3.0 WITH LGPL-3.0-linking-exception"], crate = "hakoniwa" },
+    { allow = ["LGPL-3.0-only WITH LGPL-3.0-linking-exception"], crate = "hakoniwa" },
     { allow = ["GPL-3.0-only"], crate = "hakoniwa-cli" },
 ]
 

--- a/hakoniwa/Cargo.toml
+++ b/hakoniwa/Cargo.toml
@@ -7,7 +7,7 @@ categories = ["security"]
 homepage = "https://github.com/souk4711/hakoniwa"
 repository = "https://github.com/souk4711/hakoniwa"
 include = ["src/**/*", "LICENSE", "../README.md"]
-license = "LGPL-3.0 WITH LGPL-3.0-linking-exception"
+license = "LGPL-3.0-only WITH LGPL-3.0-linking-exception"
 readme = "../README.md"
 edition = "2024"
 


### PR DESCRIPTION
SPDX has replaced "LGPL-3.0" with "LGPL-3.0-only", which causes a cargo-deny warning.

https://spdx.org/licenses/