### PR TITLE
feat: Add runctl flag to ignore cgroup initialization failures

### DIFF
--- a/hakoniwa/src/command.rs
+++ b/hakoniwa/src/command.rs
@@ -454,7 +454,25 @@ impl Command {
             // Setup cgroups.
             if request[0] & crate::runc::SETUP_CGROUPS == crate::runc::SETUP_CGROUPS {
                 #[cfg(feature = "cgroups")]
-                self.mainp_setup_cgroups(child)?;
+                {
+                    let res = self.mainp_setup_cgroups(child);
+                    let ignore_cgroup_err = self
+                        .container
+                        .runctl
+                        .contains(&crate::Runctl::CgroupsIgnoreFailure);
+
+                    match (ignore_cgroup_err, res) {
+                        (false, res) => res?,
+                        (true, Err(e)) => {
+                            log::debug!(
+                                "Ignoring cgroups initialization failure due to {:?} runctl. Error was {}",
+                                crate::Runctl::CgroupsIgnoreFailure,
+                                e,
+                            );
+                        }
+                        (true, Ok(())) => {}
+                    }
+                }
             };
 
             // Send a response back to the child process.

--- a/hakoniwa/src/runctl.rs
+++ b/hakoniwa/src/runctl.rs
@@ -18,4 +18,9 @@ pub enum Runctl {
     /// Allow the internal process to gain more privileges than its parent
     /// process. Aka do not set the no_new_privs bit.
     AllowNewPrivs,
+
+    /// Proceed without the specified cgroup resource configuration if initialization
+    /// failed, for instance if the systemd socket was not available or systemd
+    /// rejected configuration due to permissions.
+    CgroupsIgnoreFailure,
 }


### PR DESCRIPTION
In usage of hakoniwa where we configure `cgroups::Resources.cpu` to help balance out CPU priority across a bunch of jobs, we often prefer to continue execution when systemd cgroups is not available, rather than fatally error.

In the past, we tried to only configure cgroups resources if we detected a systemd socket and such, but trying to detect if its going to work ahead of time turned out to be rather brittle.