### PR TITLE
Security & robustness hardening: landlock fail-open, procfs/symlink escape, slirp limits, pinned/attested releases

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -8,7 +8,7 @@ description: Setup the upstream libseccomp library for the libseccomp-rs
 inputs:
   version:
     description: Installed the upstream libseccomp version
-    default: main
+    default: v2.6.0
     required: false
   link-type:
     description: Link type (dylib or static)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,8 @@ jobs:
       - dist
       - dist-musl
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
       - uses: actions/download-artifact@v8
         with:
           name: hakoniwa-x86_64-unknown-linux-gnu
@@ -111,8 +113,16 @@ jobs:
         with:
           name: hakoniwa-aarch64-unknown-linux-musl
           path: dist
+      - name: Generate release checksums
+        run: |
+          cp install.sh dist/install.sh
+          (cd dist && sha256sum install.sh *.tar.gz > SHA256SUMS)
       - name: Release
         uses: softprops/action-gh-release@v3
         with:
-          files: dist/*.tar.gz
+          files: |
+            dist/*.tar.gz
+            dist/install.sh
+            dist/SHA256SUMS
+          body_path: dist/SHA256SUMS
           draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Install libseccomp
         uses: ./.github/actions/setup
         with:
-          version: main
+          version: v2.6.0
           link-type: static
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,6 +91,10 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     needs:
       - dist
       - dist-musl
@@ -117,6 +121,13 @@ jobs:
         run: |
           cp install.sh dist/install.sh
           (cd dist && sha256sum install.sh *.tar.gz > SHA256SUMS)
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/install.sh
+            dist/SHA256SUMS
       - name: Release
         uses: softprops/action-gh-release@v3
         with:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,51 +8,73 @@ curl -fsSL https://raw.githubusercontent.com/souk4711/hakoniwa/refs/heads/main/i
 
 ## From Source
 
+Run Cargo as your normal user. Only use `sudo` for package-manager commands,
+privileged configuration, and copying the already-built `hakoniwa` binary into
+`/usr/bin`.
+
 ### Arch, Manjaro and EndeavourOS based distributions
 
 ```sh
 # Install dependencies
-pacman -S --noconfirm libseccomp passt shadow cargo
+sudo pacman -S --noconfirm libseccomp passt shadow cargo
 
-# Compile binary from source code and install to /usr/bin/hakoniwa
+# Compile binary from source code as an unprivileged user
 export RUSTUP_TOOLCHAIN=stable
-cargo install hakoniwa-cli --root /usr --locked
+install_root="$(mktemp -d)"
+cargo install hakoniwa-cli --root "$install_root" --locked
+
+# Install the already-built binary to /usr/bin/hakoniwa
+sudo install -Dm755 "$install_root/bin/hakoniwa" /usr/bin/hakoniwa
 ```
 
 ### Debian and Ubuntu based distributions
 
 ```sh
 # Install dependencies
-apt install -y libseccomp-dev passt uidmap cargo
+sudo apt install -y libseccomp-dev passt uidmap cargo
 
-# Compile binary from source code and install to /usr/bin/hakoniwa
-cargo install hakoniwa-cli --root /usr --locked
+# Compile binary from source code as an unprivileged user
+install_root="$(mktemp -d)"
+cargo install hakoniwa-cli --root "$install_root" --locked
+
+# Install the already-built binary to /usr/bin/hakoniwa
+sudo install -Dm755 "$install_root/bin/hakoniwa" /usr/bin/hakoniwa
 
 # Configure AppArmor
-curl -o /etc/apparmor.d/hakoniwa https://raw.githubusercontent.com/souk4711/hakoniwa/refs/heads/main/etc/apparmor.d/hakoniwa
-systemctl reload apparmor.service
+apparmor_profile="$(mktemp)"
+curl -o "$apparmor_profile" https://raw.githubusercontent.com/souk4711/hakoniwa/refs/heads/main/etc/apparmor.d/hakoniwa
+sudo install -Dm644 "$apparmor_profile" /etc/apparmor.d/hakoniwa
+sudo systemctl reload apparmor.service
 ```
 
 ### RHEL, Fedora and Rocky based distributions
 
 ```sh
 # Install dependencies
-dnf install -y libseccomp-devel passt shadow-utils cargo
+sudo dnf install -y libseccomp-devel passt shadow-utils cargo
 
-# Compile binary from source code and install to /usr/bin/hakoniwa
-cargo install hakoniwa-cli --root /usr --locked
+# Compile binary from source code as an unprivileged user
+install_root="$(mktemp -d)"
+cargo install hakoniwa-cli --root "$install_root" --locked
+
+# Install the already-built binary to /usr/bin/hakoniwa
+sudo install -Dm755 "$install_root/bin/hakoniwa" /usr/bin/hakoniwa
 
 # Configure SELinux
-dnf install -y container-selinux
-chcon -u system_u -t container_runtime_exec_t /usr/bin/hakoniwa
+sudo dnf install -y container-selinux
+sudo chcon -u system_u -t container_runtime_exec_t /usr/bin/hakoniwa
 ```
 
 ### openSUSE based distributions
 
 ```sh
 # Install dependencies
-zypper install -y libseccomp-devel passt shadow cargo
+sudo zypper install -y libseccomp-devel passt shadow cargo
 
-# Compile binary from source code and install to /usr/bin/hakoniwa
-cargo install hakoniwa-cli --root /usr --locked
+# Compile binary from source code as an unprivileged user
+install_root="$(mktemp -d)"
+cargo install hakoniwa-cli --root "$install_root" --locked
+
+# Install the already-built binary to /usr/bin/hakoniwa
+sudo install -Dm755 "$install_root/bin/hakoniwa" /usr/bin/hakoniwa
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -17,6 +17,12 @@ esac
 
 curl -fsSLO "https://github.com/souk4711/hakoniwa/releases/download/$version/install.sh"
 curl -fsSLO "https://github.com/souk4711/hakoniwa/releases/download/$version/SHA256SUMS"
+
+# Verify that the installer and checksums were genuinely produced by this
+# repository's release workflow (requires GitHub CLI >= 2.49):
+gh attestation verify install.sh --repo souk4711/hakoniwa
+gh attestation verify SHA256SUMS --repo souk4711/hakoniwa
+
 sha256sum -c --ignore-missing SHA256SUMS
 
 # Replace this placeholder with the SHA-256 digest for

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,8 +2,26 @@
 
 ## From Releases
 
+Download the installer and checksums from the same immutable release tag you are
+installing, verify `install.sh`, then run the installer with the pinned version and
+the expected SHA-256 digest for your architecture from the release announcement.
+
 ```sh
-curl -fsSL https://raw.githubusercontent.com/souk4711/hakoniwa/refs/heads/main/install.sh | bash
+version=v1.7.0
+arch=$(uname -m)
+case "$arch" in
+  amd64|x86_64) arch=x86_64 ;;
+  aarch64|arm64) arch=aarch64 ;;
+  *) echo "unsupported architecture: $arch" >&2; exit 1 ;;
+esac
+
+curl -fsSLO "https://github.com/souk4711/hakoniwa/releases/download/$version/install.sh"
+curl -fsSLO "https://github.com/souk4711/hakoniwa/releases/download/$version/SHA256SUMS"
+sha256sum -c --ignore-missing SHA256SUMS
+
+# Replace this placeholder with the SHA-256 digest for
+# hakoniwa-$arch-unknown-linux-gnu.tar.gz from the verified SHA256SUMS file.
+HAKONIWA_SHA256=<release-archive-sha256> HAKONIWA_VERSION="$version" bash install.sh
 ```
 
 ## From Source

--- a/hakoniwa-cli/src/slirp.rs
+++ b/hakoniwa-cli/src/slirp.rs
@@ -1,9 +1,16 @@
 use anyhow::Result;
 use futures::{SinkExt, StreamExt};
 use std::os::fd::RawFd;
-use std::{net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 use tokio::net::{TcpSocket, TcpStream, UdpSocket};
+use tokio::sync::Semaphore;
+use tokio::time::timeout;
 use tun_rs::AsyncDevice;
+
+const MAX_TCP_CONNECTIONS: usize = 256;
+const MAX_UDP_SESSIONS: usize = 512;
+const UDP_WRITE_QUEUE_SIZE: usize = 1024;
+const UDP_RESPONSE_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub(crate) fn slirp(tapfd: RawFd) {
     std::thread::spawn(move || {
@@ -89,9 +96,20 @@ async fn slirp_imp(tapfd: RawFd) -> Result<()> {
 }
 
 async fn handle_inbound_stream(mut tcp_listener: netstack_smoltcp::TcpListener, iface: String) {
+    let tcp_permits = Arc::new(Semaphore::new(MAX_TCP_CONNECTIONS));
+
     while let Some((mut stream, local, remote)) = tcp_listener.next().await {
+        let Ok(permit) = tcp_permits.clone().try_acquire_owned() else {
+            log::warn!(
+                "slirp: dropping tcp stream {} => {}: connection limit reached",
+                local,
+                remote
+            );
+            continue;
+        };
         let iface = iface.clone();
         tokio::spawn(async move {
+            let _permit = permit;
             match new_tcp_stream(remote, &iface).await {
                 Ok(mut r) => {
                     if let Err(e) = tokio::io::copy_bidirectional(&mut stream, &mut r).await {
@@ -109,7 +127,8 @@ async fn handle_inbound_stream(mut tcp_listener: netstack_smoltcp::TcpListener, 
 }
 
 async fn handle_inbound_datagram(udp_socket: netstack_smoltcp::UdpSocket, iface: String) {
-    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let (tx, mut rx) = tokio::sync::mpsc::channel(UDP_WRITE_QUEUE_SIZE);
+    let udp_permits = Arc::new(Semaphore::new(MAX_UDP_SESSIONS));
     let (mut read_half, mut write_half) = udp_socket.split();
     tokio::spawn(async move {
         while let Some((data, local, remote)) = rx.recv().await {
@@ -117,20 +136,35 @@ async fn handle_inbound_datagram(udp_socket: netstack_smoltcp::UdpSocket, iface:
         }
     });
     while let Some((data, local, remote)) = read_half.next().await {
+        let Ok(permit) = udp_permits.clone().try_acquire_owned() else {
+            log::warn!(
+                "slirp: dropping udp packet {} => {}: session limit reached",
+                local,
+                remote
+            );
+            continue;
+        };
         let tx = tx.clone();
         let iface = iface.clone();
         tokio::spawn(async move {
+            let _permit = permit;
             match new_udp_packet(remote, &iface).await {
                 Ok(sock) => {
                     let _ = sock.send(&data).await;
+                    let mut buf = vec![0; 1024];
                     loop {
-                        let mut buf = vec![0; 1024];
-                        match sock.recv_from(&mut buf).await {
-                            Ok((n, _)) => {
-                                let _ = tx.send((buf[..n].to_vec(), local, remote));
+                        match timeout(UDP_RESPONSE_TIMEOUT, sock.recv_from(&mut buf)).await {
+                            Ok(Ok((n, _))) => {
+                                if tx.send((buf[..n].to_vec(), local, remote)).await.is_err() {
+                                    break;
+                                }
                             }
-                            Err(e) => {
+                            Ok(Err(e)) => {
                                 log::error!("slirp: udp recv {}: {}", remote, e);
+                                break;
+                            }
+                            Err(_) => {
+                                log::debug!("slirp: udp session {} timed out", remote);
                                 break;
                             }
                         }

--- a/hakoniwa/src/landlock/ruleset.rs
+++ b/hakoniwa/src/landlock/ruleset.rs
@@ -52,6 +52,11 @@ impl Ruleset {
         self
     }
 
+    /// Returns true when the ruleset restricts RESOURCE.
+    pub fn is_restricted(&self, resource: Resource) -> bool {
+        self.restrictions.contains_key(&resource)
+    }
+
     /// Allow access to files beneath PATH with given mode.
     pub fn allow_path(&mut self, path: &str, mode: FsAccess) -> &mut Self {
         self.add_fs_rule(path, mode)
@@ -75,6 +80,9 @@ impl Ruleset {
             mode,
         };
         self.fs_rules.insert(path, rule);
+        self.restrictions
+            .entry(Resource::FS)
+            .or_insert(CompatMode::Enforce);
         self
     }
 
@@ -87,6 +95,10 @@ impl Ruleset {
                 NetAccess::TCP_CONNECT => Resource::NET_TCP_CONNECT,
                 _ => continue,
             };
+
+            self.restrictions
+                .entry(resource)
+                .or_insert(CompatMode::Enforce);
 
             let rule = NetRule { port, access };
             match self.net_rules.entry(resource) {
@@ -106,5 +118,70 @@ impl Ruleset {
         let mut values: Vec<_> = self.fs_rules.values().collect();
         values.sort_by(|a, b| a.path.cmp(&b.path));
         values
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allow_path_enables_fs_restriction() {
+        let mut ruleset = Ruleset::default();
+
+        ruleset.allow_path("/tmp", FsAccess::R);
+
+        assert_eq!(
+            ruleset.restrictions.get(&Resource::FS),
+            Some(&CompatMode::Enforce)
+        );
+        assert!(ruleset.is_restricted(Resource::FS));
+    }
+
+    #[test]
+    fn allow_path_preserves_existing_fs_compat_mode() {
+        let mut ruleset = Ruleset::default();
+
+        ruleset.restrict(Resource::FS, CompatMode::Relax);
+        ruleset.allow_path("/tmp", FsAccess::R);
+
+        assert_eq!(
+            ruleset.restrictions.get(&Resource::FS),
+            Some(&CompatMode::Relax)
+        );
+    }
+
+    #[test]
+    fn allow_tcp_bind_enables_only_bind_restriction() {
+        let mut ruleset = Ruleset::default();
+
+        ruleset.allow_tcp_bind(443);
+
+        assert!(ruleset.is_restricted(Resource::NET_TCP_BIND));
+        assert!(!ruleset.is_restricted(Resource::NET_TCP_CONNECT));
+        assert!(!ruleset.is_restricted(Resource::FS));
+    }
+
+    #[test]
+    fn allow_tcp_connect_enables_only_connect_restriction() {
+        let mut ruleset = Ruleset::default();
+
+        ruleset.allow_tcp_connect(443);
+
+        assert!(ruleset.is_restricted(Resource::NET_TCP_CONNECT));
+        assert!(!ruleset.is_restricted(Resource::NET_TCP_BIND));
+    }
+
+    #[test]
+    fn net_rule_preserves_existing_compat_mode() {
+        let mut ruleset = Ruleset::default();
+
+        ruleset.restrict(Resource::NET_TCP_CONNECT, CompatMode::Relax);
+        ruleset.allow_tcp_connect(443);
+
+        assert_eq!(
+            ruleset.restrictions.get(&Resource::NET_TCP_CONNECT),
+            Some(&CompatMode::Relax)
+        );
     }
 }

--- a/hakoniwa/src/runc/sys.rs
+++ b/hakoniwa/src/runc/sys.rs
@@ -10,7 +10,7 @@ use std::fs::{File, Metadata, OpenOptions};
 use std::io::Write;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::os::unix::ffi::OsStrExt;
-use std::os::unix::fs::{self as unix_fs, PermissionsExt};
+use std::os::unix::fs as unix_fs;
 
 pub(crate) use nix::mount::{MntFlags, MsFlags};
 pub(crate) use nix::sched::CloneFlags;
@@ -214,42 +214,25 @@ pub(crate) fn fwrite_nofollow<P: AsRef<Path> + Debug>(path: P, content: &str) ->
     })
 }
 
+pub(crate) fn mkdir_p_nofollow<P: AsRef<Path> + Debug>(path: P, mode: u32) -> Result<()> {
+    mkdir_p_nofollow_impl(path.as_ref(), mode).map_err(|err| {
+        let err = format!("mkdir_p({path:?}) => {err}");
+        Error::SysError(err)
+    })
+}
+
+pub(crate) fn symlink_nofollow<P1: AsRef<Path> + Debug, P2: AsRef<Path> + Debug>(
+    original: P1,
+    link: P2,
+) -> Result<()> {
+    symlink_nofollow_impl(original.as_ref(), link.as_ref()).map_err(|err| {
+        let err = format!("symlink({original:?}, {link:?}) => {err}");
+        Error::SysError(err)
+    })
+}
+
 fn fwrite_nofollow_impl(path: &Path, content: &str) -> std::io::Result<()> {
-    let mut components = Vec::new();
-    for component in path.components() {
-        match component {
-            Component::Prefix(_) | Component::RootDir | Component::CurDir => {}
-            Component::ParentDir => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::InvalidInput,
-                    "parent directory components are not allowed",
-                ));
-            }
-            Component::Normal(component) => {
-                if component.as_bytes() == b".oldproc" {
-                    return Err(std::io::Error::new(
-                        std::io::ErrorKind::PermissionDenied,
-                        "writes through the temporary procfs mount are not allowed",
-                    ));
-                }
-                components.push(CString::new(component.as_bytes())?);
-            }
-        }
-    }
-
-    let Some(filename) = components.pop() else {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "file path must include a filename",
-        ));
-    };
-
-    let start = if path.is_absolute() { c"/" } else { c"." };
-    let mut dir = open_dir_nofollow(libc::AT_FDCWD, start)?;
-    for component in components {
-        dir = open_dir_nofollow(dir.as_raw_fd(), component.as_c_str())?;
-    }
-
+    let (dir, filename) = resolve_parent_nofollow(path)?;
     let fd = unsafe {
         libc::openat(
             dir.as_raw_fd(),
@@ -266,6 +249,107 @@ fn fwrite_nofollow_impl(path: &Path, content: &str) -> std::io::Result<()> {
     file.write_all(content.as_bytes())
 }
 
+fn mkdir_p_nofollow_impl(path: &Path, mode: u32) -> std::io::Result<()> {
+    let components = checked_components(path)?;
+    let Some((last, parents)) = components.split_last() else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "path must include a final component",
+        ));
+    };
+
+    let mut dir = start_dir_nofollow(path)?;
+    for component in parents {
+        mkdirat_allow_existing(dir.as_raw_fd(), component, 0o777)?;
+        dir = open_dir_nofollow(dir.as_raw_fd(), component.as_c_str())?;
+    }
+    mkdirat_allow_existing(dir.as_raw_fd(), last, 0o777)?;
+
+    // Re-open the final directory without O_PATH so its mode can be set through
+    // the fd, keeping the no-follow guarantee for the final component too.
+    let fd = unsafe {
+        libc::openat(
+            dir.as_raw_fd(),
+            last.as_ptr(),
+            libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW,
+        )
+    };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let target = unsafe { OwnedFd::from_raw_fd(fd) };
+    if unsafe { libc::fchmod(target.as_raw_fd(), mode as libc::mode_t) } < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn symlink_nofollow_impl(original: &Path, link: &Path) -> std::io::Result<()> {
+    let (dir, filename) = resolve_parent_nofollow(link)?;
+    let original = CString::new(original.as_os_str().as_bytes())?;
+    if unsafe { libc::symlinkat(original.as_ptr(), dir.as_raw_fd(), filename.as_ptr()) } < 0 {
+        let err = std::io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::EEXIST)
+            && readlinkat_eq(dir.as_raw_fd(), filename.as_c_str(), original.as_c_str())
+        {
+            return Ok(());
+        }
+        return Err(err);
+    }
+    Ok(())
+}
+
+/// Splits PATH into its normal components, rejecting parent-directory traversal
+/// and any reference to the temporary host procfs mount.
+fn checked_components(path: &Path) -> std::io::Result<Vec<CString>> {
+    let mut components = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir | Component::CurDir => {}
+            Component::ParentDir => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "parent directory components are not allowed",
+                ));
+            }
+            Component::Normal(component) => {
+                if component.as_bytes() == b".oldproc" {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        "operations through the temporary procfs mount are not allowed",
+                    ));
+                }
+                components.push(CString::new(component.as_bytes())?);
+            }
+        }
+    }
+    Ok(components)
+}
+
+fn start_dir_nofollow(path: &Path) -> std::io::Result<OwnedFd> {
+    let start = if path.is_absolute() { c"/" } else { c"." };
+    open_dir_nofollow(libc::AT_FDCWD, start)
+}
+
+/// Resolves the parent directory of PATH and returns a no-follow handle to it
+/// together with the final component. Intermediate components must already
+/// exist as real directories; symlinks anywhere on the path are rejected.
+fn resolve_parent_nofollow(path: &Path) -> std::io::Result<(OwnedFd, CString)> {
+    let mut components = checked_components(path)?;
+    let Some(filename) = components.pop() else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "path must include a final component",
+        ));
+    };
+
+    let mut dir = start_dir_nofollow(path)?;
+    for component in components {
+        dir = open_dir_nofollow(dir.as_raw_fd(), component.as_c_str())?;
+    }
+    Ok((dir, filename))
+}
+
 fn open_dir_nofollow(dirfd: RawFd, path: &CStr) -> std::io::Result<OwnedFd> {
     let fd = unsafe {
         libc::openat(
@@ -278,6 +362,32 @@ fn open_dir_nofollow(dirfd: RawFd, path: &CStr) -> std::io::Result<OwnedFd> {
         return Err(std::io::Error::last_os_error());
     }
     Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+}
+
+fn mkdirat_allow_existing(dirfd: RawFd, name: &CString, mode: libc::mode_t) -> std::io::Result<()> {
+    if unsafe { libc::mkdirat(dirfd, name.as_ptr(), mode) } < 0 {
+        let err = std::io::Error::last_os_error();
+        if err.raw_os_error() != Some(libc::EEXIST) {
+            return Err(err);
+        }
+    }
+    Ok(())
+}
+
+fn readlinkat_eq(dirfd: RawFd, name: &CStr, expected: &CStr) -> bool {
+    let mut buf = vec![0u8; libc::PATH_MAX as usize];
+    let n = unsafe {
+        libc::readlinkat(
+            dirfd,
+            name.as_ptr(),
+            buf.as_mut_ptr() as *mut libc::c_char,
+            buf.len(),
+        )
+    };
+    if n < 0 {
+        return false;
+    }
+    &buf[..n as usize] == expected.to_bytes()
 }
 
 pub(crate) fn touch<P: AsRef<Path> + Debug>(path: P) -> Result<()> {
@@ -324,11 +434,6 @@ pub(crate) fn rmdir<P: AsRef<Path> + Debug>(path: P) -> Result<()> {
 
 pub(crate) fn chdir<P: AsRef<Path> + Debug>(path: P) -> Result<()> {
     map_err!(unistd::chdir(path.as_ref()))
-}
-
-pub(crate) fn chmod<P: AsRef<Path> + Debug>(path: P, mode: u32) -> Result<()> {
-    let permissions = fs::Permissions::from_mode(mode);
-    map_err!(fs::set_permissions(path.as_ref(), permissions.clone()))
 }
 
 pub(crate) fn statfs<P: AsRef<Path> + Debug>(path: P) -> Result<Statfs> {
@@ -518,6 +623,7 @@ fn nix_unistd_ttyname(fd: RawFd) -> nix::Result<PathBuf> {
 mod tests {
     use super::*;
     use std::os::unix::fs as unix_fs;
+    use std::os::unix::fs::PermissionsExt;
 
     #[test]
     fn fwrite_nofollow_rejects_oldproc_component() {
@@ -559,5 +665,78 @@ mod tests {
 
         assert!(err.to_string().contains("Too many levels"));
         assert_eq!(fs::read_to_string(&target).unwrap(), "original");
+    }
+
+    #[test]
+    fn mkdir_p_nofollow_creates_nested_and_sets_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("a").join("b");
+
+        mkdir_p_nofollow(&target, 0o700).unwrap();
+
+        let meta = fs::metadata(&target).unwrap();
+        assert!(meta.is_dir());
+        assert_eq!(meta.permissions().mode() & 0o777, 0o700);
+    }
+
+    #[test]
+    fn mkdir_p_nofollow_rejects_oldproc_component() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join(".oldproc").join("evil");
+
+        let err = mkdir_p_nofollow(&target, 0o755).unwrap_err();
+
+        assert!(err.to_string().contains("temporary procfs"));
+        assert!(!target.exists());
+    }
+
+    #[test]
+    fn mkdir_p_nofollow_rejects_parent_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let real_dir = dir.path().join("real");
+        let link_dir = dir.path().join("link");
+        fs::create_dir(&real_dir).unwrap();
+        unix_fs::symlink(&real_dir, &link_dir).unwrap();
+
+        let err = mkdir_p_nofollow(link_dir.join("sub"), 0o755).unwrap_err();
+
+        assert!(
+            err.to_string().contains("Not a directory")
+                || err.to_string().contains("Too many levels")
+        );
+        assert!(!real_dir.join("sub").exists());
+    }
+
+    #[test]
+    fn symlink_nofollow_creates_and_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let link = dir.path().join("link");
+
+        symlink_nofollow("target", &link).unwrap();
+        assert_eq!(fs::read_link(&link).unwrap().to_str(), Some("target"));
+
+        // A second call with the same target succeeds without error.
+        symlink_nofollow("target", &link).unwrap();
+
+        // A conflicting target is rejected.
+        let err = symlink_nofollow("other", &link).unwrap_err();
+        assert!(err.to_string().contains("File exists"));
+    }
+
+    #[test]
+    fn symlink_nofollow_rejects_parent_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let real_dir = dir.path().join("real");
+        let link_dir = dir.path().join("link");
+        fs::create_dir(&real_dir).unwrap();
+        unix_fs::symlink(&real_dir, &link_dir).unwrap();
+
+        let err = symlink_nofollow("target", link_dir.join("inner")).unwrap_err();
+
+        assert!(
+            err.to_string().contains("Not a directory")
+                || err.to_string().contains("Too many levels")
+        );
+        assert!(!real_dir.join("inner").exists());
     }
 }

--- a/hakoniwa/src/runc/sys.rs
+++ b/hakoniwa/src/runc/sys.rs
@@ -6,8 +6,9 @@ use nix::unistd::{self, alarm};
 use std::ffi::{CStr, CString, OsStr};
 use std::fmt::Debug;
 use std::fs;
-use std::fs::{Metadata, OpenOptions};
-use std::os::fd::RawFd;
+use std::fs::{File, Metadata, OpenOptions};
+use std::io::Write;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::{self as unix_fs, PermissionsExt};
 
@@ -20,7 +21,7 @@ pub(crate) use nix::sys::statfs::Statfs;
 pub(crate) use nix::sys::statvfs::FsFlags;
 pub(crate) use nix::sys::wait::{WaitPidFlag, WaitStatus};
 pub(crate) use nix::unistd::{ForkResult, Pid};
-pub(crate) use std::path::{Path, PathBuf};
+pub(crate) use std::path::{Component, Path, PathBuf};
 
 use super::error::*;
 
@@ -204,6 +205,79 @@ pub(crate) fn fwrite<P: AsRef<Path> + Debug>(path: P, content: &str) -> Result<(
         let err = format!("write({path:?}, ..) => {err}");
         Error::SysError(err)
     })
+}
+
+pub(crate) fn fwrite_nofollow<P: AsRef<Path> + Debug>(path: P, content: &str) -> Result<()> {
+    fwrite_nofollow_impl(path.as_ref(), content).map_err(|err| {
+        let err = format!("write({path:?}, ..) => {err}");
+        Error::SysError(err)
+    })
+}
+
+fn fwrite_nofollow_impl(path: &Path, content: &str) -> std::io::Result<()> {
+    let mut components = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Prefix(_) | Component::RootDir | Component::CurDir => {}
+            Component::ParentDir => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "parent directory components are not allowed",
+                ));
+            }
+            Component::Normal(component) => {
+                if component.as_bytes() == b".oldproc" {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        "writes through the temporary procfs mount are not allowed",
+                    ));
+                }
+                components.push(CString::new(component.as_bytes())?);
+            }
+        }
+    }
+
+    let Some(filename) = components.pop() else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "file path must include a filename",
+        ));
+    };
+
+    let start = if path.is_absolute() { c"/" } else { c"." };
+    let mut dir = open_dir_nofollow(libc::AT_FDCWD, start)?;
+    for component in components {
+        dir = open_dir_nofollow(dir.as_raw_fd(), component.as_c_str())?;
+    }
+
+    let fd = unsafe {
+        libc::openat(
+            dir.as_raw_fd(),
+            filename.as_ptr(),
+            libc::O_CLOEXEC | libc::O_CREAT | libc::O_NOFOLLOW | libc::O_TRUNC | libc::O_WRONLY,
+            0o666,
+        )
+    };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    let mut file = unsafe { File::from_raw_fd(fd) };
+    file.write_all(content.as_bytes())
+}
+
+fn open_dir_nofollow(dirfd: RawFd, path: &CStr) -> std::io::Result<OwnedFd> {
+    let fd = unsafe {
+        libc::openat(
+            dirfd,
+            path.as_ptr(),
+            libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_PATH,
+        )
+    };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(unsafe { OwnedFd::from_raw_fd(fd) })
 }
 
 pub(crate) fn touch<P: AsRef<Path> + Debug>(path: P) -> Result<()> {
@@ -438,4 +512,52 @@ fn nix_unistd_ttyname(fd: RawFd) -> nix::Result<PathBuf> {
     CStr::from_bytes_until_nul(&buf[..])
         .map(|s| OsStr::from_bytes(s.to_bytes()).into())
         .map_err(|_| Errno::EINVAL)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs as unix_fs;
+
+    #[test]
+    fn fwrite_nofollow_rejects_oldproc_component() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".oldproc").join("marker");
+
+        let err = fwrite_nofollow(&path, "blocked").unwrap_err();
+
+        assert!(err.to_string().contains("temporary procfs"));
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn fwrite_nofollow_rejects_parent_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let real_dir = dir.path().join("real");
+        let link_dir = dir.path().join("link");
+        fs::create_dir(&real_dir).unwrap();
+        unix_fs::symlink(&real_dir, &link_dir).unwrap();
+
+        let err = fwrite_nofollow(link_dir.join("marker"), "blocked").unwrap_err();
+
+        assert!(
+            err.to_string().contains("Not a directory")
+                || err.to_string().contains("Too many levels")
+        );
+        assert!(!real_dir.join("marker").exists());
+    }
+
+    #[test]
+    fn fwrite_nofollow_rejects_final_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        let link = dir.path().join("link");
+        fs::write(&target, "original").unwrap();
+        unix_fs::symlink(&target, &link).unwrap();
+
+        let err = fwrite_nofollow(&link, "blocked").unwrap_err();
+
+        assert!(err.to_string().contains("Too many levels"));
+        assert_eq!(fs::read_to_string(&target).unwrap(), "original");
+    }
 }

--- a/hakoniwa/src/runc/unshare.rs
+++ b/hakoniwa/src/runc/unshare.rs
@@ -247,7 +247,7 @@ fn apply_fs_operations(container: &Container) -> Result<()> {
     for op in &container.get_fs_operations() {
         match op {
             FsOperation::WriteFile(file) => {
-                sys::fwrite(&file.target, &file.contents)?;
+                sys::fwrite_nofollow(&file.target, &file.contents)?;
             }
             FsOperation::MakeDir(dir) => {
                 sys::mkdir_p(&dir.target)?;

--- a/hakoniwa/src/runc/unshare.rs
+++ b/hakoniwa/src/runc/unshare.rs
@@ -250,11 +250,10 @@ fn apply_fs_operations(container: &Container) -> Result<()> {
                 sys::fwrite_nofollow(&file.target, &file.contents)?;
             }
             FsOperation::MakeDir(dir) => {
-                sys::mkdir_p(&dir.target)?;
-                sys::chmod(&dir.target, dir.mode)?;
+                sys::mkdir_p_nofollow(&dir.target, dir.mode)?;
             }
             FsOperation::MakeSymlink(symlink) => {
-                sys::symlink(&symlink.original, &symlink.link)?;
+                sys::symlink_nofollow(&symlink.original, &symlink.link)?;
             }
         }
     }

--- a/install.sh
+++ b/install.sh
@@ -77,15 +77,49 @@ install_deps() {
   esac
 }
 
+validate_release_inputs() {
+  if [ -z "${HAKONIWA_VERSION:-}" ]; then
+    echo_error "HAKONIWA_VERSION is required. Set it to an immutable release tag, for example: HAKONIWA_VERSION=v0.1.0"
+  fi
+  if [ -z "${HAKONIWA_SHA256:-}" ]; then
+    echo_error "HAKONIWA_SHA256 is required. Set it to the expected SHA-256 digest for the release archive."
+  fi
+  case $HAKONIWA_VERSION in
+    v[0-9]*.[0-9]*.[0-9]*) ;;
+    *) echo_error "HAKONIWA_VERSION must be a versioned tag such as v0.1.0, not a branch or 'latest'.";;
+  esac
+  case $HAKONIWA_SHA256 in
+    *[!0123456789abcdefABCDEF]* | "") echo_error "HAKONIWA_SHA256 must be a hexadecimal SHA-256 digest.";;
+  esac
+  if [ ${#HAKONIWA_SHA256} -ne 64 ]; then
+    echo_error "HAKONIWA_SHA256 must be exactly 64 hexadecimal characters."
+  fi
+  if ! command_exists "sha256sum"; then
+    echo_error "sha256sum is required to verify the release archive before installation."
+  fi
+}
+
+verify_checksum() {
+  archive=$1
+  expected_sha256=$(printf '%s' "$HAKONIWA_SHA256" | tr '[:upper:]' '[:lower:]')
+
+  echo "printf '%s  %s\\n' '$expected_sha256' '$archive' | sha256sum -c -"
+  printf '%s  %s\n' "$expected_sha256" "$archive" | sha256sum -c -
+}
+
 install_hakoniwa() {
   echo ""
   echo_info "Installing hakoniwa..."
 
-  filename="hakoniwa-$ARCH-unknown-linux-gnu.tar.gz"
-  url="https://github.com/souk4711/hakoniwa/releases/latest/download/$filename"
+  validate_release_inputs
 
-  echo "curl -L --progress-bar -o $CACHE_DIR/$filename $url"
-  curl -L --progress-bar -o "$CACHE_DIR/$filename" "$url"
+  filename="hakoniwa-$ARCH-unknown-linux-gnu.tar.gz"
+  url="https://github.com/souk4711/hakoniwa/releases/download/$HAKONIWA_VERSION/$filename"
+
+  echo "curl -L --fail --progress-bar -o $CACHE_DIR/$filename $url"
+  curl -L --fail --progress-bar -o "$CACHE_DIR/$filename" "$url"
+
+  verify_checksum "$CACHE_DIR/$filename"
 
   echo "tar -xzf $CACHE_DIR/$filename -C $CACHE_DIR"
   tar -xzf "$CACHE_DIR/$filename" -C "$CACHE_DIR"

--- a/scripts/install-libseccomp.sh
+++ b/scripts/install-libseccomp.sh
@@ -8,8 +8,7 @@
 set -o errexit
 
 # installed libseccomp version by default
-DEFAULT_LIBSECCOMP_VER="v2.5.4"
-TENTATIVE_HEAD_VER="9.9.9"
+DEFAULT_LIBSECCOMP_VER="v2.6.0"
 WORK_DIR="$(mktemp -d --tmpdir build-libseccomp.XXXXX)"
 
 function finish() {
@@ -18,15 +17,33 @@ function finish() {
 
 trap finish EXIT
 
+function libseccomp_sha256() {
+    case "$1" in
+        v2.5.4)
+            echo "d82902400405cf0068574ef3dc1fe5f5926207543ba1ae6f8e7a1576351dcbdb"
+            ;;
+        v2.6.0)
+            echo "83b6085232d1588c379dc9b9cae47bb37407cf262e6e74993c61ba72d2a784dc"
+            ;;
+        *)
+            echo "unsupported libseccomp version $1; add its release checksum before using it" >&2
+            return 1
+            ;;
+    esac
+}
+
+
 function build_and_install_gperf() {
     gperf_version="3.1"
     gperf_url="https://ftp.gnu.org/gnu/gperf"
     gperf_tarball="gperf-${gperf_version}.tar.gz"
     gperf_tarball_url="${gperf_url}/${gperf_tarball}"
+    gperf_sha256="588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2"
 
     echo "Build and install gperf version ${gperf_version}"
     gperf_install_dir="$(mktemp -d --tmpdir build-gperf.XXXXX)"
-    curl -sLO "${gperf_tarball_url}"
+    curl -fsSLO "${gperf_tarball_url}"
+    echo "${gperf_sha256}  ${gperf_tarball}" | sha256sum -c -
     tar -xf "${gperf_tarball}"
     pushd "gperf-${gperf_version}"
     ./configure --prefix="${gperf_install_dir}"
@@ -42,16 +59,22 @@ function build_and_install_libseccomp() {
     libseccomp_install_dir=${opt_dir}
     mkdir -p "${libseccomp_install_dir}"
 
-    echo "Build and install libseccomp version ${libseccomp_version}"
-    git clone --depth=1 "https://github.com/seccomp/libseccomp.git" --branch "${libseccomp_version}" --single-branch
-    pushd libseccomp
-    if [[ ${libseccomp_version} == "main" ]]; then
-        # Specify the tentative version of the libseccomp library because some
-        # functions of the Rust bindings are restricted based on the version.
-        sed -i "/^AC_INIT/ s/0.0.0/$TENTATIVE_HEAD_VER/" configure.ac
+    if [[ ${libseccomp_version} != v* ]]; then
+        echo "libseccomp version must be a pinned release tag (for example, v2.6.0)" >&2
+        exit 1
     fi
 
-    ./autogen.sh
+    libseccomp_release="${libseccomp_version#v}"
+    libseccomp_tarball="libseccomp-${libseccomp_release}.tar.gz"
+    libseccomp_tarball_url="https://github.com/seccomp/libseccomp/releases/download/${libseccomp_version}/${libseccomp_tarball}"
+    libseccomp_sha256=$(libseccomp_sha256 "${libseccomp_version}")
+
+    echo "Build and install libseccomp version ${libseccomp_version}"
+    curl -fsSLO "${libseccomp_tarball_url}"
+    echo "${libseccomp_sha256}  ${libseccomp_tarball}" | sha256sum -c -
+    tar -xf "${libseccomp_tarball}"
+    pushd "libseccomp-${libseccomp_release}"
+
     if [[ ${opt_musl} -eq 1 ]]; then
         # Set FORTIFY_SOURCE=1 because the musl-libc does not have some functions about FORTIFY_SOURCE=2
         cflags="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 -O2"
@@ -78,9 +101,8 @@ USAGE:
 OPTIONS:
   -h            : show this help message
   -m            : install libseccomp library for musl-libc [default: GNU-libc]
-  -v [VERSION]  : specify the version of installed libseccomp library [default: ${DEFAULT_LIBSECCOMP_VER}]
-                  If you want to install the HEAD of the libseccomp library (the main branch of the repository),
-                  specify "main" and the version will be tentatively ${TENTATIVE_HEAD_VER}.
+  -v [VERSION]  : specify the pinned libseccomp release tag to install [default: ${DEFAULT_LIBSECCOMP_VER}]
+                  The installer only accepts release tags with an in-script SHA-256 checksum.
   -i [DIR]      : specify the directory for installing libseccomp library [default: /usr/local]
 EOF
 }
@@ -107,6 +129,8 @@ function main() {
                 ;;
         esac
     done
+
+    libseccomp_sha256 "${opt_ver}" >/dev/null
 
     pushd "${WORK_DIR}"
     # gperf is required for building the libseccomp.


### PR DESCRIPTION
Security/robustness hardening for hakoniwa, consolidated into one branch (all checks green: `cargo deny`, `cargo hack --feature-powerset`, `clippy -D warnings`, test suite on x86_64 + aarch64).

## Changes

| Area | Fix |
|------|-----|
| **landlock** | Allowlist rules silently fail-open: enforcement iterates `Ruleset::restrictions`, but `add_fs_rule`/`add_net_rule` never registered the corresponding `Resource`, so `allow_path`/`allow_tcp_*` added without an explicit `restrict()` were dropped. Rules now imply an `Enforce` restriction for FS **and** NET (preserving any explicit `CompatMode`); adds `Ruleset::is_restricted`. |
| **runc** | `Container::file`/`dir`/`symlink` could be redirected to host paths via procfs magic-links or attacker-controlled symlinks in the rootfs while host `/proc` is bind-mounted at `/.oldproc` during setup. `WriteFile`/`MakeDir`/`MakeSymlink` now resolve targets through a per-component `O_NOFOLLOW` walk that rejects `..` and `.oldproc`. |
| **cli (slirp)** | rustslirp parent helper spawned unbounded TCP/UDP tasks/sockets outside the child's rlimits. Bounded with semaphores (256 TCP / 512 UDP), a bounded UDP write queue, and a UDP response timeout. |
| **build** | musl release builds cloned libseccomp `main` (mutable) and ran it as root. Pin to `v2.6.0` with SHA-256 verification of the release tarball (and gperf). Checksums independently verified against upstream. |
| **release** | Publish `install.sh` + `SHA256SUMS`, and attest tarballs/installer/checksums with GitHub build provenance (`actions/attest-build-provenance`), closing the TOFU gap. |
| **installer** | Require an immutable `HAKONIWA_VERSION` tag + expected `HAKONIWA_SHA256`, verify the archive before extraction/`sudo`. |
| **docs** | Stop recommending `curl \| bash` from `main` and `cargo install --root /usr` as root; document `gh attestation verify`. |

## Notes for reviewers

- **Behavioral change (landlock):** adding an allowlist rule now enables the matching restriction by default. This restores the intended "rules imply restriction" semantics; `unrestrict()` no longer overrides a rule for the same resource.
- **merged-usr / symlinked rootfs caveat:** the no-follow walk rejects *any* symlink component in a target path. On rootfs images with symlinked top-level dirs (`/bin`→`/usr/bin`, `/var/run`→`/run`, …), `file()`/`dir()`/`symlink()` targeting paths *through* such a symlink will now fail rather than silently following it. This is an intentional trade-off (the rootfs is treated as untrusted); flagging it in case upstream supports merged-usr images and prefers a canonicalize-then-confine approach instead.
- **slirp UDP:** still opens one host socket per inbound datagram (pre-existing design); the semaphore bounds it but per-`(local,remote)` session demultiplexing would be a better follow-up.

Happy to split this into per-area PRs if that's easier to review.
