### PR TITLE
fix(runc): apply container fs operations after detaching host /proc

### DIFF
--- a/hakoniwa/src/runc/unshare.rs
+++ b/hakoniwa/src/runc/unshare.rs
@@ -87,9 +87,6 @@ fn mount(command: &Command, container: &Container) -> Result<()> {
     // Make MsFlags::MS_RDONLY option work properly.
     remount_rdonly(container)?;
 
-    // Apply filesystem operations.
-    apply_fs_operations(container)?;
-
     // Done.
     Ok(())
 }
@@ -311,6 +308,13 @@ fn mount2(container: &Container) -> Result<()> {
         sys::unmount("/.oldproc")?;
         sys::rmdir("/.oldproc")?;
     }
+
+    // Apply filesystem operations only after the host /proc bind mount has been
+    // detached, so a symlink in an untrusted rootfs cannot redirect a write
+    // through procfs magic-links into the host. With no host path reachable,
+    // ordinary symlink resolution is safe (and keeps working on merged-usr
+    // rootfs images where e.g. /bin -> /usr/bin).
+    apply_fs_operations(container)?;
 
     if !container.runctl.contains(&Runctl::RootdirRW) {
         let mut options = MsFlags::MS_BIND | MsFlags::MS_REC | MsFlags::MS_REMOUNT;


### PR DESCRIPTION
The original concern: `Container::file`/`dir`/`symlink` resolved their targets while the host `/proc` bind mount was still present at `/.oldproc`, so a symlink in an untrusted rootfs could redirect a write through a procfs magic-link onto the host.

Reworked per your feedback (both points). Instead of a no-follow walk that rejects every symlinked path component — which would have broken merged-usr rootfs images like Arch (`/bin` -> `/usr/bin`) — this just **moves `apply_fs_operations` into the tidyup phase, after the host `/proc` mount is detached** (and the old rootfs is already gone). Once no host path is reachable, ordinary symlink resolution is safe again, so merged-usr keeps working and there is no behavior change for normal use.

This is structurally stronger than randomizing the `.oldproc` name (no reliance on the mount-point name being unguessable), and it needs no extra dependencies. `.oldproc` still has to stay mounted until the new procfs is in place (the kernel requires a fully-visible procfs to mount one unprivileged), so detaching-then-applying is the natural ordering.

Tested on a merged-usr host (Arch-like, `/bin` -> `/usr/bin`): `test_file`, `test_dir`, `test_dir_chmod`, `test_symlink`, proc/tmpfs/bind mount tests all pass.