### PR TITLE
chore(build): pin libseccomp release sources

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -8,7 +8,7 @@ description: Setup the upstream libseccomp library for the libseccomp-rs
 inputs:
   version:
     description: Installed the upstream libseccomp version
-    default: main
+    default: v2.6.0
     required: false
   link-type:
     description: Link type (dylib or static)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Install libseccomp
         uses: ./.github/actions/setup
         with:
-          version: main
+          version: v2.6.0
           link-type: static
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/scripts/install-libseccomp.sh
+++ b/scripts/install-libseccomp.sh
@@ -8,8 +8,7 @@
 set -o errexit
 
 # installed libseccomp version by default
-DEFAULT_LIBSECCOMP_VER="v2.5.4"
-TENTATIVE_HEAD_VER="9.9.9"
+DEFAULT_LIBSECCOMP_VER="v2.6.0"
 WORK_DIR="$(mktemp -d --tmpdir build-libseccomp.XXXXX)"
 
 function finish() {
@@ -18,15 +17,33 @@ function finish() {
 
 trap finish EXIT
 
+function libseccomp_sha256() {
+    case "$1" in
+        v2.5.4)
+            echo "d82902400405cf0068574ef3dc1fe5f5926207543ba1ae6f8e7a1576351dcbdb"
+            ;;
+        v2.6.0)
+            echo "83b6085232d1588c379dc9b9cae47bb37407cf262e6e74993c61ba72d2a784dc"
+            ;;
+        *)
+            echo "unsupported libseccomp version $1; add its release checksum before using it" >&2
+            return 1
+            ;;
+    esac
+}
+
+
 function build_and_install_gperf() {
     gperf_version="3.1"
     gperf_url="https://ftp.gnu.org/gnu/gperf"
     gperf_tarball="gperf-${gperf_version}.tar.gz"
     gperf_tarball_url="${gperf_url}/${gperf_tarball}"
+    gperf_sha256="588546b945bba4b70b6a3a616e80b4ab466e3f33024a352fc2198112cdbb3ae2"
 
     echo "Build and install gperf version ${gperf_version}"
     gperf_install_dir="$(mktemp -d --tmpdir build-gperf.XXXXX)"
-    curl -sLO "${gperf_tarball_url}"
+    curl -fsSLO "${gperf_tarball_url}"
+    echo "${gperf_sha256}  ${gperf_tarball}" | sha256sum -c -
     tar -xf "${gperf_tarball}"
     pushd "gperf-${gperf_version}"
     ./configure --prefix="${gperf_install_dir}"
@@ -42,16 +59,22 @@ function build_and_install_libseccomp() {
     libseccomp_install_dir=${opt_dir}
     mkdir -p "${libseccomp_install_dir}"
 
-    echo "Build and install libseccomp version ${libseccomp_version}"
-    git clone --depth=1 "https://github.com/seccomp/libseccomp.git" --branch "${libseccomp_version}" --single-branch
-    pushd libseccomp
-    if [[ ${libseccomp_version} == "main" ]]; then
-        # Specify the tentative version of the libseccomp library because some
-        # functions of the Rust bindings are restricted based on the version.
-        sed -i "/^AC_INIT/ s/0.0.0/$TENTATIVE_HEAD_VER/" configure.ac
+    if [[ ${libseccomp_version} != v* ]]; then
+        echo "libseccomp version must be a pinned release tag (for example, v2.6.0)" >&2
+        exit 1
     fi
 
-    ./autogen.sh
+    libseccomp_release="${libseccomp_version#v}"
+    libseccomp_tarball="libseccomp-${libseccomp_release}.tar.gz"
+    libseccomp_tarball_url="https://github.com/seccomp/libseccomp/releases/download/${libseccomp_version}/${libseccomp_tarball}"
+    libseccomp_sha256=$(libseccomp_sha256 "${libseccomp_version}")
+
+    echo "Build and install libseccomp version ${libseccomp_version}"
+    curl -fsSLO "${libseccomp_tarball_url}"
+    echo "${libseccomp_sha256}  ${libseccomp_tarball}" | sha256sum -c -
+    tar -xf "${libseccomp_tarball}"
+    pushd "libseccomp-${libseccomp_release}"
+
     if [[ ${opt_musl} -eq 1 ]]; then
         # Set FORTIFY_SOURCE=1 because the musl-libc does not have some functions about FORTIFY_SOURCE=2
         cflags="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1 -O2"
@@ -78,9 +101,8 @@ USAGE:
 OPTIONS:
   -h            : show this help message
   -m            : install libseccomp library for musl-libc [default: GNU-libc]
-  -v [VERSION]  : specify the version of installed libseccomp library [default: ${DEFAULT_LIBSECCOMP_VER}]
-                  If you want to install the HEAD of the libseccomp library (the main branch of the repository),
-                  specify "main" and the version will be tentatively ${TENTATIVE_HEAD_VER}.
+  -v [VERSION]  : specify the pinned libseccomp release tag to install [default: ${DEFAULT_LIBSECCOMP_VER}]
+                  The installer only accepts release tags with an in-script SHA-256 checksum.
   -i [DIR]      : specify the directory for installing libseccomp library [default: /usr/local]
 EOF
 }
@@ -107,6 +129,8 @@ function main() {
                 ;;
         esac
     done
+
+    libseccomp_sha256 "${opt_ver}" >/dev/null
 
     pushd "${WORK_DIR}"
     # gperf is required for building the libseccomp.


### PR DESCRIPTION
musl release builds cloned libseccomp `main` (mutable) and ran it as root. Pin to `v2.6.0` with SHA-256 verification of the release tarball (and gperf). Checksums independently verified against upstream.

Split out of #164.