### PR TITLE
docs: avoid running cargo install as root

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,51 +8,85 @@ curl -fsSL https://raw.githubusercontent.com/souk4711/hakoniwa/refs/heads/main/i
 
 ## From Source
 
+> [!TIP]
+> Run Cargo as your normal user. Only use `sudo` for package-manager commands,
+> privileged configuration, and copying the already-built `hakoniwa` binary into
+> `/usr/bin`.
+
 ### Arch, Manjaro and EndeavourOS based distributions
 
 ```sh
 # Install dependencies
-pacman -S --noconfirm libseccomp passt shadow cargo
+sudo pacman -S --noconfirm libseccomp passt shadow cargo
 
-# Compile binary from source code and install to /usr/bin/hakoniwa
+# Compile binary from source code as an unprivileged user
 export RUSTUP_TOOLCHAIN=stable
-cargo install hakoniwa-cli --root /usr --locked
+tmp_install="$(mktemp -d)"
+cargo install hakoniwa-cli --root "$tmp_install" --locked
+
+# Install the already-built binary to /usr/bin/hakoniwa
+sudo install -Dm755 "$tmp_install/bin/hakoniwa" /usr/bin/hakoniwa
 ```
 
 ### Debian and Ubuntu based distributions
 
 ```sh
 # Install dependencies
-apt install -y libseccomp-dev passt uidmap cargo
+sudo apt install -y libseccomp-dev passt uidmap cargo
 
-# Compile binary from source code and install to /usr/bin/hakoniwa
-cargo install hakoniwa-cli --root /usr --locked
+# Compile binary from source code as an unprivileged user
+tmp_install="$(mktemp -d)"
+cargo install hakoniwa-cli --root "$tmp_install" --locked
+
+# Install the already-built binary to /usr/bin/hakoniwa
+sudo install -Dm755 "$tmp_install/bin/hakoniwa" /usr/bin/hakoniwa
 
 # Configure AppArmor
-curl -o /etc/apparmor.d/hakoniwa https://raw.githubusercontent.com/souk4711/hakoniwa/refs/heads/main/etc/apparmor.d/hakoniwa
-systemctl reload apparmor.service
+sudo tee /etc/apparmor.d/hakoniwa >/dev/null <<'EOF'
+# This profile allows everything and only exists to give the
+# application a name instead of having the label "unconfined"
+
+abi <abi/4.0>,
+include <tunables/global>
+
+profile hakoniwa /usr/bin/hakoniwa flags=(unconfined) {
+  userns,
+
+  # Site-specific additions and overrides. See local/README for details.
+  include if exists <local/hakoniwa>
+}
+EOF
+sudo systemctl reload apparmor.service
 ```
 
 ### RHEL, Fedora and Rocky based distributions
 
 ```sh
 # Install dependencies
-dnf install -y libseccomp-devel passt shadow-utils cargo
+sudo dnf install -y libseccomp-devel passt shadow-utils cargo
 
-# Compile binary from source code and install to /usr/bin/hakoniwa
-cargo install hakoniwa-cli --root /usr --locked
+# Compile binary from source code as an unprivileged user
+tmp_install="$(mktemp -d)"
+cargo install hakoniwa-cli --root "$tmp_install" --locked
+
+# Install the already-built binary to /usr/bin/hakoniwa
+sudo install -Dm755 "$tmp_install/bin/hakoniwa" /usr/bin/hakoniwa
 
 # Configure SELinux
-dnf install -y container-selinux
-chcon -u system_u -t container_runtime_exec_t /usr/bin/hakoniwa
+sudo dnf install -y container-selinux
+sudo chcon -u system_u -t container_runtime_exec_t /usr/bin/hakoniwa
 ```
 
 ### openSUSE based distributions
 
 ```sh
 # Install dependencies
-zypper install -y libseccomp-devel passt shadow cargo
+sudo zypper install -y libseccomp-devel passt shadow cargo
 
-# Compile binary from source code and install to /usr/bin/hakoniwa
-cargo install hakoniwa-cli --root /usr --locked
+# Compile binary from source code as an unprivileged user
+tmp_install="$(mktemp -d)"
+cargo install hakoniwa-cli --root "$tmp_install" --locked
+
+# Install the already-built binary to /usr/bin/hakoniwa
+sudo install -Dm755 "$tmp_install/bin/hakoniwa" /usr/bin/hakoniwa
 ```


### PR DESCRIPTION
Stop recommending `cargo install --root /usr` as root: build as an unprivileged user into a temp root and `sudo install` only the resulting binary; same for the AppArmor profile.

(The `curl | bash`→pinned-release and `gh attestation verify` doc changes ride with the `chore(installer)` / `chore(release)` PRs that introduce those flows.)

Split out of #164.