### PR TITLE
chore(installer): verify release installer artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,8 @@ jobs:
       - dist
       - dist-musl
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
       - uses: actions/download-artifact@v8
         with:
           name: hakoniwa-x86_64-unknown-linux-gnu
@@ -111,8 +113,16 @@ jobs:
         with:
           name: hakoniwa-aarch64-unknown-linux-musl
           path: dist
+      - name: Generate release checksums
+        run: |
+          cp install.sh dist/install.sh
+          (cd dist && sha256sum install.sh *.tar.gz > SHA256SUMS)
       - name: Release
         uses: softprops/action-gh-release@v3
         with:
-          files: dist/*.tar.gz
+          files: |
+            dist/*.tar.gz
+            dist/install.sh
+            dist/SHA256SUMS
+          body_path: dist/SHA256SUMS
           draft: true

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,8 +2,26 @@
 
 ## From Releases
 
+Download the installer and checksums from the same immutable release tag you are
+installing, verify `install.sh`, then run the installer with the pinned version and
+the expected SHA-256 digest for your architecture from the release announcement.
+
 ```sh
-curl -fsSL https://raw.githubusercontent.com/souk4711/hakoniwa/refs/heads/main/install.sh | bash
+version=v1.7.0
+arch=$(uname -m)
+case "$arch" in
+  amd64|x86_64) arch=x86_64 ;;
+  aarch64|arm64) arch=aarch64 ;;
+  *) echo "unsupported architecture: $arch" >&2; exit 1 ;;
+esac
+
+curl -fsSLO "https://github.com/souk4711/hakoniwa/releases/download/$version/install.sh"
+curl -fsSLO "https://github.com/souk4711/hakoniwa/releases/download/$version/SHA256SUMS"
+sha256sum -c --ignore-missing SHA256SUMS
+
+# Replace this placeholder with the SHA-256 digest for
+# hakoniwa-$arch-unknown-linux-gnu.tar.gz from the verified SHA256SUMS file.
+HAKONIWA_SHA256=<release-archive-sha256> HAKONIWA_VERSION="$version" bash install.sh
 ```
 
 ## From Source

--- a/install.sh
+++ b/install.sh
@@ -77,15 +77,49 @@ install_deps() {
   esac
 }
 
+validate_release_inputs() {
+  if [ -z "${HAKONIWA_VERSION:-}" ]; then
+    echo_error "HAKONIWA_VERSION is required. Set it to an immutable release tag, for example: HAKONIWA_VERSION=v0.1.0"
+  fi
+  if [ -z "${HAKONIWA_SHA256:-}" ]; then
+    echo_error "HAKONIWA_SHA256 is required. Set it to the expected SHA-256 digest for the release archive."
+  fi
+  case $HAKONIWA_VERSION in
+    v[0-9]*.[0-9]*.[0-9]*) ;;
+    *) echo_error "HAKONIWA_VERSION must be a versioned tag such as v0.1.0, not a branch or 'latest'.";;
+  esac
+  case $HAKONIWA_SHA256 in
+    *[!0123456789abcdefABCDEF]* | "") echo_error "HAKONIWA_SHA256 must be a hexadecimal SHA-256 digest.";;
+  esac
+  if [ ${#HAKONIWA_SHA256} -ne 64 ]; then
+    echo_error "HAKONIWA_SHA256 must be exactly 64 hexadecimal characters."
+  fi
+  if ! command_exists "sha256sum"; then
+    echo_error "sha256sum is required to verify the release archive before installation."
+  fi
+}
+
+verify_checksum() {
+  archive=$1
+  expected_sha256=$(printf '%s' "$HAKONIWA_SHA256" | tr '[:upper:]' '[:lower:]')
+
+  echo "printf '%s  %s\\n' '$expected_sha256' '$archive' | sha256sum -c -"
+  printf '%s  %s\n' "$expected_sha256" "$archive" | sha256sum -c -
+}
+
 install_hakoniwa() {
   echo ""
   echo_info "Installing hakoniwa..."
 
-  filename="hakoniwa-$ARCH-unknown-linux-gnu.tar.gz"
-  url="https://github.com/souk4711/hakoniwa/releases/latest/download/$filename"
+  validate_release_inputs
 
-  echo "curl -L --progress-bar -o $CACHE_DIR/$filename $url"
-  curl -L --progress-bar -o "$CACHE_DIR/$filename" "$url"
+  filename="hakoniwa-$ARCH-unknown-linux-gnu.tar.gz"
+  url="https://github.com/souk4711/hakoniwa/releases/download/$HAKONIWA_VERSION/$filename"
+
+  echo "curl -L --fail --progress-bar -o $CACHE_DIR/$filename $url"
+  curl -L --fail --progress-bar -o "$CACHE_DIR/$filename" "$url"
+
+  verify_checksum "$CACHE_DIR/$filename"
 
   echo "tar -xzf $CACHE_DIR/$filename -C $CACHE_DIR"
   tar -xzf "$CACHE_DIR/$filename" -C "$CACHE_DIR"


### PR DESCRIPTION
Require an immutable `HAKONIWA_VERSION` tag + expected `HAKONIWA_SHA256`, verify the archive before extraction/`sudo`. The release workflow now publishes `install.sh` + `SHA256SUMS` alongside the tarballs.

Split out of #164.