### PR TITLE
chore(installer): enforce HTTPS/TLS1.2 for installer downloads

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,7 +3,7 @@
 ## From Releases
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/souk4711/hakoniwa/refs/heads/main/install.sh | bash
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/souk4711/hakoniwa/refs/heads/main/install.sh | bash
 ```
 
 ## From Source

--- a/install.sh
+++ b/install.sh
@@ -84,8 +84,8 @@ install_hakoniwa() {
   filename="hakoniwa-$ARCH-unknown-linux-gnu.tar.gz"
   url="https://github.com/souk4711/hakoniwa/releases/latest/download/$filename"
 
-  echo "curl -L --progress-bar -o $CACHE_DIR/$filename $url"
-  curl -L --progress-bar -o "$CACHE_DIR/$filename" "$url"
+  echo "curl --proto '=https' --tlsv1.2 -fL --progress-bar -o $CACHE_DIR/$filename $url"
+  curl --proto '=https' --tlsv1.2 -fL --progress-bar -o "$CACHE_DIR/$filename" "$url"
 
   echo "tar -xzf $CACHE_DIR/$filename -C $CACHE_DIR"
   tar -xzf "$CACHE_DIR/$filename" -C "$CACHE_DIR"


### PR DESCRIPTION
Per your suggestion on #170: keep the simple `curl | bash` flow but force HTTPS with TLS >= 1.2 (and fail on HTTP errors) for both the bootstrap line in `INSTALL.md` and the release-tarball download inside `install.sh`. Prevents protocol-downgrade / plaintext MITM without adding install-time friction.

Replaces #170 (closed).