### PR TITLE
feat: support spawning hakoniwa::Command as session leader

### DIFF
--- a/hakoniwa/src/runc.rs
+++ b/hakoniwa/src/runc.rs
@@ -262,6 +262,12 @@ fn spawn(command: &Command, container: &Container, writer: &mut Option<PipeWrite
     // Reset SIGPIPE to SIG_DFL.
     sys::reset_sigpipe()?;
 
+    // Start a new session and acquire the controlling terminal on stdin.
+    if container.runctl.contains(&Runctl::NewSession) {
+        sys::setsid()?;
+        sys::set_controlling_terminal_stdin()?;
+    }
+
     // Set resource limit.
     rlimit::setrlimit(container)?;
 

--- a/hakoniwa/src/runc/sys.rs
+++ b/hakoniwa/src/runc/sys.rs
@@ -117,6 +117,22 @@ pub(crate) fn set_keepcaps(attribute: bool) -> Result<()> {
     map_err!(prctl::set_keepcaps(attribute))
 }
 
+pub(crate) fn setsid() -> Result<Pid> {
+    map_err!(unistd::setsid())
+}
+
+pub(crate) fn set_controlling_terminal_stdin() -> Result<()> {
+    // Make the terminal referenced by stdin the controlling terminal of the
+    // current session. Must be called after setsid().
+    if unsafe { libc::ioctl(libc::STDIN_FILENO, libc::TIOCSCTTY, 0) } == ERRNO_SENTINEL {
+        let err = Errno::last();
+        let err = format!("ioctl(STDIN, TIOCSCTTY) => {err}");
+        Err(Error::SysError(err))
+    } else {
+        Ok(())
+    }
+}
+
 pub(crate) fn sigaction(signal: Signal, sigaction: &SigAction) -> Result<SigAction> {
     unsafe { signal::sigaction(signal, sigaction) }.map_err(|err| {
         let err = format!("sigaction({signal:?}, ..) => {err}");

--- a/hakoniwa/src/runctl.rs
+++ b/hakoniwa/src/runctl.rs
@@ -16,6 +16,16 @@ pub enum Runctl {
     /// rejected configuration due to permissions.
     IgnoreCgroupSetupFailed,
 
+    /// Start a new session and acquire the controlling terminal before
+    /// executing the program.
+    ///
+    /// Just prior to `execve`, this calls `setsid(2)` so the process becomes
+    /// the leader of a new session and process group, then issues
+    /// `ioctl(stdin, TIOCSCTTY)` to make the terminal referenced by stdin the
+    /// controlling terminal of that session. This is typically what you want
+    /// when running an interactive shell so that job control works correctly.
+    NewSession,
+
     /// Fallback when the specific configuration is not applicable. E.g try to
     /// remount a bind mount again after the first attempt failed on source
     /// filesystems that have nodev, noexec, nosuid, etc.

--- a/hakoniwa/tests/command_test.rs
+++ b/hakoniwa/tests/command_test.rs
@@ -332,6 +332,46 @@ mod command_test {
         assert!(r.is_none());
     }
 
+    // Allocate a pty and run a command whose stdin/stdout/stderr are all its
+    // slave end, with `Runctl::NewSession`. The closure runs in the container
+    // right after `setsid()` + `ioctl(stdin, TIOCSCTTY)` have executed, so we
+    // can assert the process leads a fresh session and owns the pty as its
+    // controlling terminal.
+    #[test]
+    fn test_runctl_new_session() {
+        let pty = nix::pty::openpty(None, None).unwrap();
+        let stdin = pty.slave.try_clone().unwrap();
+        let stdout = pty.slave.try_clone().unwrap();
+        let stderr = pty.slave.try_clone().unwrap();
+
+        let assert_new_session = || -> i32 {
+            unsafe {
+                // setsid() must have made us the leader of a new session.
+                if libc::getsid(0) != libc::getpid() {
+                    return 11;
+                }
+                // ioctl(TIOCSCTTY) must have made the pty on stdin our
+                // controlling terminal: its session id is now our pid.
+                if libc::tcgetsid(libc::STDIN_FILENO) != libc::getpid() {
+                    return 12;
+                }
+            }
+            0
+        };
+
+        let mut container = Container::new();
+        container.rootfs("/").unwrap().runctl(Runctl::NewSession);
+        let status = unsafe { container.command_from_closure(assert_new_session) }
+            .stdin(stdin)
+            .stdout(stdout)
+            .stderr(stderr)
+            .status()
+            .unwrap();
+
+        drop(pty.master);
+        assert!(status.success(), "exit_code={:?}", status.exit_code);
+    }
+
     #[test]
     fn test_output_stdout_piped() {
         let output = command("/bin/echo").arg("Hello, World!").output().unwrap();


### PR DESCRIPTION
When using hakoniwa to spawn an interactive shell (i.e. `bash -l`), job control and signals via the terminal rely on specific tty wiring, namely:

 - The tty knowing the _controlling process_ and inversely the process knowing the controlling terminal (for signal delivery)
 - New values for process session ID (for job control)

This PR makes it possible for these parameters to be set in the manner that an interactive+tty-controlled process would need.