### PR TITLE
fix: capture metrics on signal-killed processes

### DIFF
--- a/hakoniwa/src/runc.rs
+++ b/hakoniwa/src/runc.rs
@@ -184,7 +184,28 @@ fn reap(child: Pid, command: &Command, container: &Container) -> Result<ExitStat
                 sys::ptrace_cont(pid, None)?
             }
             WaitStatus::Stopped(pid, Signal::SIGTRAP) => sys::ptrace_cont(pid, None)?,
-            WaitStatus::Stopped(pid, signal) => sys::ptrace_cont(pid, Some(signal))?,
+            WaitStatus::Stopped(pid, signal) => {
+                // Capture metrics for ANY signal before forwarding.
+                // ptrace_cont can return ESRCH if the child died between
+                // the waitpid stop and the cont call — capture now to
+                // avoid losing data.
+                proc_pid_smaps_rollup = reap_proc_smaps_rollup(pid, container).unwrap_or(None);
+                proc_pid_status = reap_proc_status(pid, container).unwrap_or(None);
+                let deliver = (signal != Signal::SIGTRAP).then_some(signal);
+                match sys::ptrace_cont(pid, deliver) {
+                    Ok(()) => {}
+                    Err(_) => {
+                        break ExitStatus {
+                            code: 128 + signal as i32,
+                            reason: format!("process received signal {signal}"),
+                            exit_code: None,
+                            rusage: None,
+                            proc_pid_smaps_rollup: proc_pid_smaps_rollup.clone(),
+                            proc_pid_status: proc_pid_status.clone(),
+                        };
+                    }
+                }
+            }
             _ => break ExitStatus::new_failure(&format!("waitpid(..) => {ws:?}")),
         };
     };


### PR DESCRIPTION
The PTRACE wait loop in `reap()` would lose all metrics (rusage,
proc_status, smaps_rollup) when a process was killed by a signal.

When ptrace catches a signal stop (e.g. SIGSEGV from rlimit AS
   enforcement, SIGKILL from wall timeout), `ptrace_cont` can return
   ESRCH if the child dies between the waitpid notification and the
   cont call. The propagated error caused the entire `reap()` to
   return `ExitStatus::FAILURE` with null metrics.

Changes in `hakoniwa/src/runc.rs`:

- Capture `/proc/<pid>/status` and `/proc/<pid>/smaps_rollup` on
  every `WaitStatus::Stopped(pid, signal)` before forwarding the
  signal, so the data is available even if `ptrace_cont` fails.
- On ESRCH from `ptrace_cont`, return a proper ExitStatus with the
  captured metrics and signal info instead of propagating the error.
- Suppress SIGTRAP (internal ptrace signal) on continue; forward
  all other signals normally.

This means metrics are now available for all kill paths: wall timeout,
rlimit AS, rlimit CPU, cgroup OOM, and any signal-delivered
termination. Previously they were null for most of these cases.

Previously:
```
ExitStatus {
    code: 125,
    reason: "cont(Pid(4097979), Some(SIGSEGV)) => ESRCH: No such process",
    exit_code: None,
    rusage: None,
    proc_pid_smaps_rollup: None,
    proc_pid_status: None,
}
```

Now:
```
ExitStatus {
    code: 137,
    reason: "process(././program) received signal SIGKILL",
    exit_code: None,
    rusage: Some(
        Rusage {
            ...
        },
    ),
    proc_pid_smaps_rollup: Some(
        ProcPidSmapsRollup {
            ...
        },
    ),
    proc_pid_status: Some(
        ProcPidStatus {
            ...
        },
    ),
}
```