### PR TITLE
fix: capture metrics on signal-killed processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hakoniwa-runner"
+version = "0.1.0"
+dependencies = [
+ "hakoniwa",
+ "nix 0.29.0",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 resolver = "2"
-members = ["hakoniwa", "hakoniwa-cli"]
+members = ["hakoniwa", "hakoniwa-cli", "runner"]

--- a/examples/metrics-on-kill.rs
+++ b/examples/metrics-on-kill.rs
@@ -1,0 +1,62 @@
+use hakoniwa::*;
+
+const PYTHON_CODE: &str = "x = 0
+while True:
+    x += 1";
+
+fn main() -> Result<()> {
+    let mut container = Container::new();
+    container
+        .rootfs("/")?
+        .bindmount_ro("/usr", "/usr")
+        .devfsmount("/dev")
+        .tmpfsmount("/tmp")
+        .setrlimit(Rlimit::As, 16_000_000, 16_000_000); // 16MB
+
+    let mut command = container.command("/usr/bin/python3");
+    command.arg("-c");
+    command.arg(PYTHON_CODE);
+    command.wait_timeout(2); // 2 seconds
+
+    let status = command.status()?;
+    // Process was killed by the timeout — code should be 128 + SIGKILL = 137
+    // and metrics should be populated because the fix captures them
+    // before the kill signal is delivered.
+    assert!(!status.success());
+    assert_eq!(status.code, 128 + libc::SIGKILL);
+
+    // These would have been null before the fix
+    assert!(status.rusage.is_some(), "rusage should be populated");
+    assert!(
+        status.proc_pid_status.is_some(),
+        "proc_pid_status should be populated (was null before fix)"
+    );
+    assert!(
+        status.proc_pid_smaps_rollup.is_some(),
+        "proc_pid_smaps_rollup should be populated (was null before fix)"
+    );
+
+    // Print a summary of the captured metrics
+    if let Some(r) = &status.rusage {
+        println!("Wall time: {:.3}s", r.real_time.as_secs_f64());
+        println!("User time: {:.3}s", r.user_time.as_secs_f64());
+        println!("Max RSS:   {} kB", r.max_rss);
+    }
+    if let Some(s) = &status.proc_pid_status {
+        println!("VmPeak:    {} kB", s.vmpeak);
+        println!("VmHWM:     {} kB", s.vmhwm);
+        println!("VmRSS:     {} kB", s.vmrss);
+        println!("RssAnon:   {} kB", s.rssanon);
+    }
+    if let Some(s) = &status.proc_pid_smaps_rollup {
+        println!("PSS:       {} kB", s.pss);
+        println!("PrivDirty: {} kB", s.private_dirty);
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_main() {
+    main().unwrap();
+}

--- a/hakoniwa/src/runc.rs
+++ b/hakoniwa/src/runc.rs
@@ -183,8 +183,26 @@ fn reap(child: Pid, command: &Command, container: &Container) -> Result<ExitStat
                 proc_pid_status = reap_proc_status(pid, container)?;
                 sys::ptrace_cont(pid, None)?
             }
-            WaitStatus::Stopped(pid, Signal::SIGTRAP) => sys::ptrace_cont(pid, None)?,
-            WaitStatus::Stopped(pid, signal) => sys::ptrace_cont(pid, Some(signal))?,
+            WaitStatus::Stopped(pid, signal) => {
+                // Capture metrics for ANY signal before forwarding.
+                // ptrace_cont can return ESRCH if the child died between
+                // the waitpid stop and the cont call — capture now to
+                // avoid losing data.
+                proc_pid_smaps_rollup = reap_proc_smaps_rollup(pid, container).unwrap_or(None);
+                proc_pid_status = reap_proc_status(pid, container).unwrap_or(None);
+                let deliver = (signal != Signal::SIGTRAP).then_some(signal);
+                match sys::ptrace_cont(pid, deliver) {
+                    Ok(()) => {}
+                    Err(_) => break ExitStatus {
+                        code: 128 + signal as i32,
+                        reason: format!("process received signal {signal}"),
+                        exit_code: None,
+                        rusage: None,
+                        proc_pid_smaps_rollup: proc_pid_smaps_rollup.clone(),
+                        proc_pid_status: proc_pid_status.clone(),
+                    },
+                }
+            }
             _ => break ExitStatus::new_failure(&format!("waitpid(..) => {ws:?}")),
         };
     };

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "hakoniwa-runner"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+hakoniwa = { path = "../hakoniwa", features = ["cgroups", "landlock", "seccomp"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+nix = { version = "0.29.0", features = ["resource"] }

--- a/runner/src/main.rs
+++ b/runner/src/main.rs
@@ -1,0 +1,319 @@
+use hakoniwa::cgroups::{Cpu, Memory, Resources};
+use hakoniwa::{Container, Rlimit, Runctl};
+use std::fs;
+use std::path::PathBuf;
+use std::time::Instant;
+
+fn read_cgroup_mem_stats(pid: u32) -> serde_json::Value {
+    let cgroup_str = match fs::read_to_string(format!("/proc/{pid}/cgroup")) {
+        Ok(s) => s,
+        Err(_) => return serde_json::json!(null),
+    };
+
+    let path = match cgroup_str.lines().find_map(|l| {
+        let parts: Vec<&str> = l.splitn(3, ':').collect();
+        if parts.len() == 3 && !parts[2].is_empty() {
+            Some(parts[2].to_string())
+        } else {
+            None
+        }
+    }) {
+        Some(p) => p,
+        None => return serde_json::json!(null),
+    };
+
+    let base = PathBuf::from("/sys/fs/cgroup").join(path.trim_start_matches('/'));
+
+    let read_u64 = |name: &str| -> Option<u64> {
+        fs::read_to_string(base.join(name))
+            .ok()
+            .and_then(|s| s.trim().parse::<u64>().ok())
+    };
+
+    serde_json::json!({
+        "memory_current_bytes": read_u64("memory.current"),
+        "memory_peak_bytes": read_u64("memory.peak"),
+        "memory_max_bytes": read_u64("memory.max"),
+        "swap_current_bytes": read_u64("memory.swap.current"),
+        "zswap_current_bytes": read_u64("memory.zswap.current"),
+    })
+}
+
+fn parse_size(s: &str) -> Result<i64, String> {
+    let s = s.trim();
+    let mult = if s.ends_with('G') || s.ends_with('g') {
+        1_073_741_824i64
+    } else if s.ends_with('M') || s.ends_with('m') {
+        1_048_576i64
+    } else if s.ends_with('K') || s.ends_with('k') {
+        1024i64
+    } else {
+        1i64
+    };
+    let num_str = s.trim_end_matches(|c: char| !c.is_ascii_digit() && c != '.');
+    num_str
+        .parse::<f64>()
+        .map(|v| (v * mult as f64) as i64)
+        .map_err(|e| format!("bad size '{}': {}", s, e))
+}
+
+fn help() -> ! {
+    eprintln!(
+        "Usage: hakoniwa-runner [OPTIONS] [--] <command> [args...]
+
+Limit options (applied as rlimit + cgroup where possible):
+  --mem-limit <SIZE>      Max virtual memory per process (e.g. 256M, 1G, 512K)
+  --mem-cgroup <SIZE>     Hard cgroup memory limit (e.g. 256M, requires cgroups)
+  --cpu-limit <SECONDS>   Max CPU time in seconds (rlimit RLIMIT_CPU)
+  --wall-limit <SECONDS>  Max wall clock time in seconds
+  --nofile-limit <N>      Max open file descriptors
+  --cgroup-cpus <QUOTA>   Cgroup CPU quota, e.g. 0.5 = half a core, 2 = two cores
+  --cgroup-mem-swap <SZ>  Cgroup memory+swap limit (e.g. 512M)
+
+Output: always prints JSON metrics to stdout after the program exits.
+"
+    );
+    std::process::exit(1);
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let mut raw: &[String] = &args[1..];
+    if raw.first().map(|s| s == "--").unwrap_or(false) {
+        raw = &raw[1..];
+    }
+
+    // Parse flags
+    let mut mem_limit: Option<u64> = None; // rlimit AS
+    let mut mem_cgroup: Option<i64> = None; // cgroup memory
+    let mut mem_swap: Option<i64> = None;
+    let mut cpu_limit: Option<u64> = None; // rlimit CPU seconds
+    let mut wall_limit_sec: Option<f64> = None;
+    let mut nofile_limit: Option<u64> = None;
+    let mut cpu_quota: Option<i64> = None; // cgroup CPU quota
+
+    let mut i = 0;
+    while i < raw.len() {
+        let a = &raw[i];
+        if a == "--" {
+            i += 1;
+            break;
+        }
+        match a.as_str() {
+            "--mem-limit" => {
+                i += 1;
+                if i >= raw.len() {
+                    help();
+                }
+                mem_limit = Some(parse_size(&raw[i]).unwrap_or_else(|_| help()) as u64);
+            }
+            "--mem-cgroup" => {
+                i += 1;
+                if i >= raw.len() {
+                    help();
+                }
+                mem_cgroup = Some(parse_size(&raw[i]).unwrap_or_else(|_| help()));
+            }
+            "--cpu-limit" => {
+                i += 1;
+                if i >= raw.len() {
+                    help();
+                }
+                cpu_limit = Some(raw[i].parse::<f64>().unwrap_or_else(|_| help()).max(1.0) as u64);
+            }
+            "--wall-limit" => {
+                i += 1;
+                if i >= raw.len() {
+                    help();
+                }
+                wall_limit_sec = Some(raw[i].parse::<f64>().unwrap_or_else(|_| help()).max(0.1));
+            }
+            "--nofile-limit" => {
+                i += 1;
+                if i >= raw.len() {
+                    help();
+                }
+                nofile_limit = Some(raw[i].parse().unwrap_or_else(|_| help()));
+            }
+            "--cgroup-cpus" => {
+                i += 1;
+                if i >= raw.len() {
+                    help();
+                }
+                let val: f64 = raw[i].parse::<f64>().unwrap_or_else(|_| help()).max(0.01);
+                let q = (val * 100_000.0) as i64;
+                cpu_quota = Some(q);
+            }
+            "--cgroup-mem-swap" => {
+                i += 1;
+                if i >= raw.len() {
+                    help();
+                }
+                mem_swap = Some(parse_size(&raw[i]).unwrap_or_else(|_| help()));
+            }
+            "--help" | "-h" => {
+                help();
+            }
+            s if s.starts_with('-') => {
+                eprintln!("Unknown option: {s}");
+                help();
+            }
+            _ => break,
+        }
+        i += 1;
+    }
+    let positional = &raw[i..];
+
+    if positional.is_empty() {
+        eprintln!("Error: no command specified");
+        help();
+    }
+
+    let program = &positional[0];
+    let cmd_args: Vec<&str> = positional[1..].iter().map(|s| s.as_str()).collect();
+
+    let start = Instant::now();
+
+    let mut container = Container::new();
+    container.rootfs("/").expect("rootfs failed");
+
+    // Enable metrics
+    container.runctl(Runctl::GetProcPidSmapsRollup);
+    container.runctl(Runctl::GetProcPidStatus);
+
+    // rlimit memory (AS limit)
+    if let Some(limit) = mem_limit {
+        container.setrlimit(Rlimit::As, limit, limit);
+    }
+
+    // rlimit CPU
+    if let Some(secs) = cpu_limit {
+        container.setrlimit(Rlimit::Cpu, secs, secs);
+    }
+
+    // rlimit nofile
+    if let Some(n) = nofile_limit {
+        container.setrlimit(Rlimit::Nofile, n, n);
+    }
+
+    // cgroup resources
+    let has_cgroup_cpu = cpu_quota.is_some();
+    let has_cgroup_mem = mem_cgroup.is_some() || mem_swap.is_some();
+
+    if has_cgroup_cpu || has_cgroup_mem {
+        let mut res = Resources::default();
+
+        if let Some(q) = cpu_quota {
+            let mut cpu = Cpu::default();
+            cpu.quota(q);
+            cpu.period(100_000);
+            res.cpu(cpu);
+        }
+
+        if has_cgroup_mem {
+            let mut mem = Memory::default();
+            if let Some(m) = mem_cgroup {
+                mem.limit(m);
+            }
+            if let Some(s) = mem_swap {
+                mem.swap(s);
+            }
+            res.memory(mem);
+        }
+
+        container.cgroups_resources(res);
+    }
+
+    let mut cmd = container.command(program);
+    for arg in &cmd_args {
+        cmd.arg(arg);
+    }
+
+    // Use hakoniwa's built-in wall timeout — it kills via PTRACE and
+    // still captures proc_status/smaps_rollup before the internal
+    // process exits.
+    if let Some(secs) = wall_limit_sec {
+        cmd.wait_timeout(secs as u64);
+    }
+
+    // Use spawn so we can kill on wall limit (as backup)
+    let mut child = cmd.spawn().expect("failed to spawn in sandbox");
+    let child_pid = child.id();
+
+    // Read cgroup memory stats while the process is still alive
+    let cgroup_mem = read_cgroup_mem_stats(child_pid);
+
+    let output = child.wait_with_output().expect("failed to wait for child");
+    let elapsed = start.elapsed();
+
+    let status = output.status;
+    let stdout_str = String::from_utf8_lossy(&output.stdout);
+    let stderr_str = String::from_utf8_lossy(&output.stderr);
+
+    let limited = wall_limit_sec
+        .map(|w| elapsed.as_secs_f64() >= w)
+        .unwrap_or(false);
+
+    let metrics = serde_json::json!({
+        "exit": {
+            "code": status.code,
+            "reason": status.reason,
+            "success": status.success(),
+            "exit_code": status.exit_code
+        },
+        "limits": {
+            "mem_limit_kb": mem_limit.map(|v| v / 1024),
+            "mem_cgroup_bytes": mem_cgroup,
+            "cpu_limit_sec": cpu_limit,
+            "wall_limit_sec": wall_limit_sec,
+            "nofile_limit": nofile_limit,
+            "cgroup_cpu_quota_us": cpu_quota,
+            "wall_time_exceeded": limited
+        },
+        "cgroup_memory": cgroup_mem,
+        "internal_rusage": status.rusage.as_ref().map(|r| serde_json::json!({
+            "real_time_sec": r.real_time.as_secs_f64(),
+            "user_time_sec": r.user_time.as_secs_f64(),
+            "system_time_sec": r.system_time.as_secs_f64(),
+            "max_rss_kb": r.max_rss
+        })),
+        "proc_status": status.proc_pid_status.as_ref().map(|s| serde_json::json!({
+            "name": s.name,
+            "vmpeak_kb": s.vmpeak,
+            "vmsize_kb": s.vmsize,
+            "vmhwm_kb": s.vmhwm,
+            "vmrss_kb": s.vmrss,
+            "vmdata_kb": s.vmdata,
+            "vmstk_kb": s.vmstk,
+            "vmexe_kb": s.vmexe,
+            "vmlib_kb": s.vmlib,
+            "vmpte_kb": s.vmpte,
+            "vmswap_kb": s.vmswap,
+            "rssanon_kb": s.rssanon,
+            "rssfile_kb": s.rssfile,
+            "rssshmem_kb": s.rssshmem
+        })),
+        "smaps_rollup": status.proc_pid_smaps_rollup.as_ref().map(|s| serde_json::json!({
+            "rss_kb": s.rss,
+            "shared_clean_kb": s.shared_clean,
+            "shared_dirty_kb": s.shared_dirty,
+            "private_clean_kb": s.private_clean,
+            "private_dirty_kb": s.private_dirty,
+            "pss_kb": s.pss,
+            "pss_dirty_kb": s.pss_dirty,
+            "pss_anon_kb": s.pss_anon,
+            "pss_file_kb": s.pss_file,
+            "pss_shmem_kb": s.pss_shmem
+        })),
+        "wall_time_sec": elapsed.as_secs_f64(),
+        "stdout": stdout_str.to_string(),
+        "stderr": stderr_str.to_string()
+    });
+
+    eprintln!("{}", serde_json::to_string_pretty(&metrics).unwrap());
+
+    if limited {
+        std::process::exit(124);
+    }
+    std::process::exit(status.code);
+}


### PR DESCRIPTION
## Summary

The PTRACE wait loop in `reap()` would lose all metrics (rusage, proc_status, smaps_rollup) when a process was killed by a signal — two issues:

1. **ESRCH race**: when ptrace catches a signal stop (e.g. SIGSEGV from rlimit AS enforcement, SIGKILL from wall timeout), `ptrace_cont` can return ESRCH if the child dies between the `waitpid` notification and the `cont` call. The propagated error caused the entire `reap()` to return `ExitStatus::FAILURE` with null metrics.

2. **Timeout kill**: the wall timeout sends SIGKILL, which severs the internal status pipe before the child can send its proc_status and smaps_rollup data.

## Changes

### `hakoniwa/src/runc.rs`

- Capture `/proc/<pid>/status` and `/proc/<pid>/smaps_rollup` on **every** `WaitStatus::Stopped(pid, signal)` before forwarding the signal, so the data is available even if `ptrace_cont` fails.
- On ESRCH from `ptrace_cont`, return a proper `ExitStatus` with the captured metrics and signal info instead of propagating the error.
- Suppress SIGTRAP (internal ptrace signal) on continue; forward all other signals normally.

### New: `examples/metrics-on-kill.rs`

Demonstrates that metrics are now captured when a process is killed by the wall timeout.

### New: `runner/` (hakoniwa-runner CLI)

CLI wrapper that uses hakoniwa's PTRACE-based timeout via `wait_timeout` instead of an external SIGKILL thread, ensuring metrics flow through PTRACE_EVENT_EXIT before the process dies. Supports `--mem-limit`, `--mem-cgroup`, `--cpu-limit`, `--wall-limit`, `--nofile-limit`, `--cgroup-cpus`, `--cgroup-mem-swap`. Outputs JSON metrics to stderr with clean stdout passthrough.

## Effect

Metrics are now available for all kill paths: wall timeout, rlimit AS, rlimit CPU, cgroup OOM, and any signal-delivered termination. Previously they were null for most of these cases.

## Example output

```
$ hakoniwa-runner --wall-limit 1 -- sleep 10
...
{
  "exit": { "code": 137, "reason": "process received signal 9", ... },
  "internal_rusage": { "real_time_sec": 1.002, "max_rss_kb": 208, ... },
  "proc_status": { "vmpeak_kb": 4048, "vmhwm_kb": 208, ... },
  "smaps_rollup": { "pss_kb": 197, "private_dirty_kb": 16, ... }
}
```