### PR TITLE
fix: don't abort container setup if rmdir(.oldproc) is EBUSY

### DIFF
--- a/hakoniwa/src/runc/unshare.rs
+++ b/hakoniwa/src/runc/unshare.rs
@@ -312,7 +312,9 @@ fn mount2(command: &Command, container: &Container) -> Result<()> {
 
         let oldproc = format!("/{0}", command.runtime_mount_oldproc);
         sys::unmount(&oldproc)?;
-        sys::rmdir(&oldproc)?;
+        // Best-effort: unmount is MNT_DETACH, so a recursive /proc bind with
+        // submounts (e.g. binfmt_misc) can still be busy here.
+        let _ = sys::rmdir(&oldproc);
     }
 
     if !container.runctl.contains(&Runctl::RootdirRW) {


### PR DESCRIPTION
`Container::new()` + `rootfs("/")` fails on hosts whose `/proc` has a submount (`binfmt_misc` is the usual one):

```
rmdir("/.oldproc-<uuid>") => Device or resource busy
```

Setup bind-mounts host `/proc` onto `.oldproc` with `MS_REC` (a non-recursive bind is `EINVAL`). Teardown then does a lazy `umount2(MNT_DETACH)` and immediately `rmdir`s the placeholder. Submounts have not detached yet, so `rmdir` returns `EBUSY` and setup aborts.

The leftover directory lives in the ephemeral mount namespace and is gone when the container exits. Treat the `rmdir` as best-effort.

Seen with hakoniwa as an unprivileged-build backend that must `rootfs("/")` to reach the host toolchain.